### PR TITLE
Fix vite peer dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.10.1",
     "typescript": "~5.8.3",
-    "vite": "^7.0.0"
+    "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- resolve dev install errors by using a vite version compatible with `@preact/preset-vite`

## Testing
- `npm install` *(fails: 403 Forbidden - no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685b5de7f958832485c13bf28f378686