### PR TITLE
Fix import of FunctionalComponent

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 
 export const Carousel: FunctionalComponent = () => (
   <div id="mainCarousel" class="carousel slide" data-bs-ride="carousel">

--- a/src/components/Reservations.tsx
+++ b/src/components/Reservations.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 
 export const Reservations: FunctionalComponent = () => (
   <section id="reservas" class="py-5" style="background:linear-gradient(180deg, black, red)">

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 
 export const AboutPage: FunctionalComponent = () => (
   <section class="py-5 text-white" style="background:#111">

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 import { Contact } from '../components/Contact'
 
 export const ContactPage: FunctionalComponent = () => <Contact />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 import { Carousel } from '../components/Carousel'
 import { Reservations } from '../components/Reservations'
 

--- a/src/pages/MenuPage.tsx
+++ b/src/pages/MenuPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 
 export const MenuPage: FunctionalComponent = () => (
   <section class="py-5 text-white" style="background:black">

--- a/src/pages/ReservasPage.tsx
+++ b/src/pages/ReservasPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent } from 'preact'
+import { type FunctionalComponent } from 'preact'
 import { Reservations } from '../components/Reservations'
 
 export const ReservasPage: FunctionalComponent = () => <Reservations />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,4 @@
-import { createContext, FunctionalComponent } from 'preact'
+import { createContext, type FunctionalComponent } from 'preact'
 import { useContext, useEffect, useState } from 'preact/hooks'
 
 interface Route {


### PR DESCRIPTION
## Summary
- use `import type` for `FunctionalComponent` so Vite stops looking for a runtime export

## Testing
- `npm run build` *(fails: Cannot find module 'preact', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685b7b13074483249e02e2160655ac3a