### PR TITLE
Add reservation modal and backend integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+reservations.db
+python/reservations.db

--- a/python/create_reservation.py
+++ b/python/create_reservation.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+from reservation import get_connection, initialize_schema, create_public_reservation
+
+
+def main():
+    data = json.load(sys.stdin)
+    db_path = os.path.join(os.path.dirname(__file__), 'reservations.db')
+    conn = get_connection(db_path)
+    initialize_schema(conn)
+    try:
+        res_id = create_public_reservation(
+            conn,
+            customer_mobile=data["customer_mobile"],
+            customer_username=data.get("customer_username"),
+            customer_name=data.get("customer_name"),
+            customer_phone=data.get("customer_phone"),
+            customer_email=data.get("customer_email"),
+            reservation_date=data["reservation_date"],
+            number_of_people=int(data["number_of_people"]),
+            special_requests=data.get("special_requests"),
+        )
+        print(json.dumps({"reservation_id": res_id}))
+    except Exception as exc:
+        print(json.dumps({"error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/app.js
+++ b/server/app.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import authRoutes from './routes/auth.js';
+import reservationRoutes from './routes/reservations.js';
 
 const app = express();
 
 app.use(express.json());
 app.use('/auth', authRoutes);
+app.use('/reservations', reservationRoutes);
 
 export default app;

--- a/server/routes/reservations.js
+++ b/server/routes/reservations.js
@@ -1,0 +1,44 @@
+import { Router } from 'express'
+import { spawn } from 'child_process'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const router = Router()
+
+router.post('/', (req, res) => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const scriptPath = path.join(__dirname, '..', '..', 'python', 'create_reservation.py')
+  const child = spawn('python', [scriptPath])
+
+  child.stdin.write(JSON.stringify(req.body))
+  child.stdin.end()
+
+  let output = ''
+  let errorOutput = ''
+  child.stdout.on('data', data => {
+    output += data.toString()
+  })
+  child.stderr.on('data', data => {
+    errorOutput += data.toString()
+  })
+
+  child.on('close', code => {
+    if (code === 0) {
+      try {
+        const result = JSON.parse(output)
+        res.json(result)
+      } catch (err) {
+        res.status(500).json({ error: 'Error procesando la reserva' })
+      }
+    } else {
+      try {
+        const err = JSON.parse(output || errorOutput)
+        res.status(400).json(err)
+      } catch (e) {
+        res.status(500).json({ error: errorOutput || 'Error procesando la reserva' })
+      }
+    }
+  })
+})
+
+export default router

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom'
 import Header from './components/Header'
 import LoginModal from './components/LoginModal'
 import RegisterModal from './components/RegisterModal'
+import ReservationModal from './components/ReservationModal'
 import Footer from './components/Footer'
 import Home from './pages/Home'
 import About from './pages/About'
@@ -14,6 +15,7 @@ export default function App() {
       <Header />
       <LoginModal />
       <RegisterModal />
+      <ReservationModal />
       <main className="flex-fill pt-5">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -14,7 +14,13 @@ export default function Hero() {
     >
       <div className="container">
         <h1 className="display-4 fw-bold mb-4">¡La mejor hamburguesa de la ciudad!</h1>
-        <a href="#" className="btn btn-danger btn-lg">Haz tu pedido</a>
+        <button
+          className="btn btn-reserva btn-lg rounded-pill px-4 fw-bold"
+          data-bs-toggle="modal"
+          data-bs-target="#reservationModal"
+        >
+          Haz tu reserva
+        </button>
       </div>
     </section>
   )

--- a/src/components/ReservationModal.tsx
+++ b/src/components/ReservationModal.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react'
+
+interface FormState {
+  customer_name: string
+  customer_phone: string
+  customer_mobile: string
+  customer_email: string
+  reservation_date: string
+  number_of_people: string
+  special_requests: string
+}
+
+export default function ReservationModal() {
+  const [form, setForm] = useState<FormState>({
+    customer_name: '',
+    customer_phone: '',
+    customer_mobile: '',
+    customer_email: '',
+    reservation_date: '',
+    number_of_people: '1',
+    special_requests: ''
+  })
+  const [message, setMessage] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  function updateField(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    const { name, value } = e.target
+    setForm(f => ({ ...f, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMessage(null)
+    try {
+      const res = await fetch('/reservations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...form,
+          number_of_people: parseInt(form.number_of_people)
+        })
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setSuccess(true)
+        setMessage('Reserva creada exitosamente')
+        setForm({
+          customer_name: '',
+          customer_phone: '',
+          customer_mobile: '',
+          customer_email: '',
+          reservation_date: '',
+          number_of_people: '1',
+          special_requests: ''
+        })
+      } else {
+        setSuccess(false)
+        setMessage(data.error || 'Error al crear la reserva')
+      }
+    } catch (err) {
+      setSuccess(false)
+      setMessage('Error al crear la reserva')
+    }
+  }
+
+  return (
+    <div className="modal fade" id="reservationModal" tabIndex={-1} aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">Haz tu reserva</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div className="modal-body">
+            {message && (
+              <div className={`alert ${success ? 'alert-success' : 'alert-danger'}`} role="alert">
+                {message}
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="needs-validation" noValidate>
+              <div className="mb-3">
+                <label className="form-label">Nombre</label>
+                <input
+                  type="text"
+                  name="customer_name"
+                  className="form-control"
+                  value={form.customer_name}
+                  onChange={updateField}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Teléfono</label>
+                <input
+                  type="text"
+                  name="customer_phone"
+                  className="form-control"
+                  value={form.customer_phone}
+                  onChange={updateField}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Móvil *</label>
+                <input
+                  type="text"
+                  name="customer_mobile"
+                  className="form-control"
+                  value={form.customer_mobile}
+                  onChange={updateField}
+                  required
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Email</label>
+                <input
+                  type="email"
+                  name="customer_email"
+                  className="form-control"
+                  value={form.customer_email}
+                  onChange={updateField}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Fecha y hora *</label>
+                <input
+                  type="datetime-local"
+                  name="reservation_date"
+                  className="form-control"
+                  value={form.reservation_date}
+                  onChange={updateField}
+                  required
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Número de personas *</label>
+                <input
+                  type="number"
+                  name="number_of_people"
+                  className="form-control"
+                  value={form.number_of_people}
+                  onChange={updateField}
+                  min="1"
+                  required
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Peticiones especiales</label>
+                <textarea
+                  name="special_requests"
+                  className="form-control"
+                  rows={3}
+                  value={form.special_requests}
+                  onChange={updateField}
+                />
+              </div>
+              <button type="submit" className="btn btn-dark w-100 rounded-pill fw-bold">
+                Reservar
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -50,3 +50,21 @@ section {
   border-color: #ff5722;
   color: #fff;
 }
+
+/* Reserva button styling */
+.btn-reserva {
+  background: linear-gradient(45deg, #000, #ff5722);
+  color: #fff;
+  border: none;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+.btn-reserva:hover {
+  opacity: 0.85;
+  transform: scale(1.02);
+  color: #fff;
+}
+
+.modal-backdrop.show {
+  backdrop-filter: blur(4px);
+}


### PR DESCRIPTION
## Summary
- upgrade hero button from "Haz tu pedido" to "Haz tu reserva"
- create ReservationModal component
- style button and modal backdrop
- add server route to handle reservation creation using existing python module
- expose reservations route in express app
- introduce helper script to create reservations via CLI

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `node -e "require('./server/routes/reservations.js'); console.log('ok')"` *(fails: Cannot find package 'express')*
- `python python/create_reservation.py <<EOF {"customer_mobile":"987654321","reservation_date":"2031-01-01T12:00","number_of_people":3} EOF`

------
https://chatgpt.com/codex/tasks/task_e_685b82d4b7448324b85c62cbfdc480a1