### PR TITLE
Improve login and register modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <title>Alrock Burger</title>
   </head>
   <body>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -2,24 +2,33 @@ import React from 'react'
 
 export default function LoginModal() {
   return (
-    <div className="modal fade" id="loginModal" tabIndex={-1} aria-hidden="true">
-      <div className="modal-dialog">
+    <div className="modal fade premium-modal" id="loginModal" tabIndex={-1} aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered">
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title">Inicio de sesión</h5>
-            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <h5 className="modal-title">
+              <img src="/img/logo.png" alt="logo" style={{ height: '30px' }} />
+              Inicia sesión
+            </h5>
+            <button type="button" className="btn-close rounded-circle" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div className="modal-body">
             <form>
               <div className="mb-3">
-                <label className="form-label">Email</label>
-                <input type="email" className="form-control" />
+                <label className="form-label">Usuario o correo</label>
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-person-fill" /></span>
+                  <input type="text" className="form-control" />
+                </div>
               </div>
               <div className="mb-3">
                 <label className="form-label">Contraseña</label>
-                <input type="password" className="form-control" />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-lock-fill" /></span>
+                  <input type="password" className="form-control" />
+                </div>
               </div>
-              <button type="submit" className="btn btn-primary w-100">Ingresar</button>
+              <button type="submit" className="btn premium-submit w-100">Ingresar</button>
             </form>
           </div>
         </div>

--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -37,6 +37,24 @@ export default function RegisterModal() {
   const [message, setMessage] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
+  async function checkAvailability(field: 'username' | 'email', value: string) {
+    if (!value) return
+    try {
+      const res = await fetch(`/auth/check?${field}=${encodeURIComponent(value)}`)
+      const data = await res.json()
+      if (data[`${field}Exists`]) {
+        setErrors(err => ({ ...err, [field]: `${field === 'username' ? 'Nombre de usuario' : 'Correo'} no disponible` }))
+      } else {
+        setErrors(err => {
+          const { [field]: _removed, ...rest } = err
+          return rest
+        })
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
   function updateField(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
     const { name, value, type, checked } = e.target
     setForm(f => ({ ...f, [name]: type === 'checkbox' ? checked : value }))
@@ -125,12 +143,15 @@ export default function RegisterModal() {
   }
 
   return (
-    <div className="modal fade" id="registerModal" tabIndex={-1} aria-hidden="true">
-      <div className="modal-dialog">
+    <div className="modal fade premium-modal" id="registerModal" tabIndex={-1} aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered modal-lg">
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title">Crea tu cuenta</h5>
-            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <h5 className="modal-title">
+              <img src="/img/logo.png" alt="logo" style={{ height: '30px' }} />
+              Crea tu cuenta
+            </h5>
+            <button type="button" className="btn-close rounded-circle" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div className="modal-body">
             {message && (
@@ -139,121 +160,161 @@ export default function RegisterModal() {
               </div>
             )}
             <form onSubmit={handleSubmit} noValidate>
+              <h6 className="premium-modal-section-title">Cuenta</h6>
               <div className="mb-3">
                 <label className="form-label">Nombre de usuario</label>
-                <input
-                  name="username"
-                  type="text"
-                  className={`form-control ${errors.username ? 'is-invalid' : ''}`}
-                  value={form.username}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-person-fill" /></span>
+                  <input
+                    name="username"
+                    type="text"
+                    className={`form-control ${errors.username ? 'is-invalid' : ''}`}
+                    value={form.username}
+                    onChange={updateField}
+                    onBlur={e => checkAvailability('username', e.target.value)}
+                  />
+                </div>
                 {errors.username && <div className="invalid-feedback">{errors.username}</div>}
               </div>
               <div className="mb-3">
                 <label className="form-label">Nombre</label>
-                <input
-                  name="user"
-                  type="text"
-                  className={`form-control ${errors.user ? 'is-invalid' : ''}`}
-                  value={form.user}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-person-badge-fill" /></span>
+                  <input
+                    name="user"
+                    type="text"
+                    className={`form-control ${errors.user ? 'is-invalid' : ''}`}
+                    value={form.user}
+                    onChange={updateField}
+                  />
+                </div>
                 {errors.user && <div className="invalid-feedback">{errors.user}</div>}
               </div>
               <div className="mb-3">
                 <label className="form-label">Correo electrónico</label>
-                <input
-                  name="email"
-                  type="email"
-                  className={`form-control ${errors.email ? 'is-invalid' : ''}`}
-                  value={form.email}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-envelope-fill" /></span>
+                  <input
+                    name="email"
+                    type="email"
+                    className={`form-control ${errors.email ? 'is-invalid' : ''}`}
+                    value={form.email}
+                    onChange={updateField}
+                    onBlur={e => checkAvailability('email', e.target.value)}
+                  />
+                </div>
                 {errors.email && <div className="invalid-feedback">{errors.email}</div>}
               </div>
               <div className="mb-3">
                 <label className="form-label">Repite tu correo electrónico</label>
-                <input
-                  name="repeat_email"
-                  type="email"
-                  className={`form-control ${errors.repeat_email ? 'is-invalid' : ''}`}
-                  value={form.repeat_email}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-envelope-fill" /></span>
+                  <input
+                    name="repeat_email"
+                    type="email"
+                    className={`form-control ${errors.repeat_email ? 'is-invalid' : ''}`}
+                    value={form.repeat_email}
+                    onChange={updateField}
+                  />
+                </div>
                 {errors.repeat_email && <div className="invalid-feedback">{errors.repeat_email}</div>}
               </div>
+
+              <h6 className="premium-modal-section-title">Seguridad</h6>
               <div className="mb-3">
                 <label className="form-label">Contraseña</label>
-                <input
-                  name="password"
-                  type="password"
-                  className={`form-control ${errors.password ? 'is-invalid' : ''}`}
-                  value={form.password}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-lock-fill" /></span>
+                  <input
+                    name="password"
+                    type="password"
+                    className={`form-control ${errors.password ? 'is-invalid' : ''}`}
+                    value={form.password}
+                    onChange={updateField}
+                  />
+                </div>
                 {errors.password && <div className="invalid-feedback">{errors.password}</div>}
               </div>
               <div className="mb-3">
                 <label className="form-label">Repite tu contraseña</label>
-                <input
-                  name="repeat_password"
-                  type="password"
-                  className={`form-control ${errors.repeat_password ? 'is-invalid' : ''}`}
-                  value={form.repeat_password}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-lock-fill" /></span>
+                  <input
+                    name="repeat_password"
+                    type="password"
+                    className={`form-control ${errors.repeat_password ? 'is-invalid' : ''}`}
+                    value={form.repeat_password}
+                    onChange={updateField}
+                  />
+                </div>
                 {errors.repeat_password && <div className="invalid-feedback">{errors.repeat_password}</div>}
               </div>
+
+              <h6 className="premium-modal-section-title">Datos personales</h6>
               <div className="mb-3">
                 <label className="form-label">Teléfono</label>
-                <input
-                  name="phone"
-                  type="text"
-                  className="form-control"
-                  value={form.phone}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-telephone-fill" /></span>
+                  <input
+                    name="phone"
+                    type="text"
+                    className="form-control"
+                    value={form.phone}
+                    onChange={updateField}
+                  />
+                </div>
               </div>
               <div className="mb-3">
                 <label className="form-label">Fecha de nacimiento</label>
-                <input
-                  name="birth_date"
-                  type="date"
-                  className="form-control"
-                  value={form.birth_date}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-calendar-date-fill" /></span>
+                  <input
+                    name="birth_date"
+                    type="date"
+                    className="form-control"
+                    value={form.birth_date}
+                    onChange={updateField}
+                  />
+                </div>
               </div>
               <div className="mb-3">
                 <label className="form-label">Dirección</label>
-                <input
-                  name="address"
-                  type="text"
-                  className="form-control"
-                  value={form.address}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-geo-alt-fill" /></span>
+                  <input
+                    name="address"
+                    type="text"
+                    className="form-control"
+                    value={form.address}
+                    onChange={updateField}
+                  />
+                </div>
               </div>
               <div className="mb-3">
                 <label className="form-label">País</label>
-                <input
-                  name="country"
-                  type="text"
-                  className="form-control"
-                  value={form.country}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-flag-fill" /></span>
+                  <input
+                    name="country"
+                    type="text"
+                    className="form-control"
+                    value={form.country}
+                    onChange={updateField}
+                  />
+                </div>
               </div>
               <div className="mb-3">
                 <label className="form-label">Ciudad</label>
-                <input
-                  name="city"
-                  type="text"
-                  className="form-control"
-                  value={form.city}
-                  onChange={updateField}
-                />
+                <div className="input-group dark-input-group">
+                  <span className="input-group-text"><i className="bi bi-building" /></span>
+                  <input
+                    name="city"
+                    type="text"
+                    className="form-control"
+                    value={form.city}
+                    onChange={updateField}
+                  />
+                </div>
               </div>
               <div className="form-check mb-3">
                 <input
@@ -266,7 +327,7 @@ export default function RegisterModal() {
                 <label className="form-check-label">Acepto los términos y condiciones</label>
                 {errors.accepted_terms && <div className="invalid-feedback">{errors.accepted_terms}</div>}
               </div>
-              <button type="submit" className="btn btn-primary w-100">
+              <button type="submit" className="btn premium-submit w-100">
                 Registrarse
               </button>
             </form>

--- a/src/index.css
+++ b/src/index.css
@@ -72,3 +72,88 @@ section {
   color: #fff;
   box-shadow: 0 0 10px rgba(255, 87, 34, 0.5);
 }
+/* Premium modal overlay */
+.modal-backdrop.show {
+  background: radial-gradient(circle at center, rgba(255,87,34,0.2), rgba(0,0,0,0.8));
+  backdrop-filter: blur(6px);
+}
+
+/* Premium modal container */
+.premium-modal .modal-dialog {
+  min-height: calc(100vh - 1rem);
+  display: flex;
+  align-items: center;
+}
+
+.premium-modal .modal-content {
+  background: linear-gradient(to bottom right, #222, #000);
+  border-radius: 1.5rem;
+  border: none;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.6);
+  padding: 1.5rem;
+  color: #fff;
+}
+
+.premium-modal .modal-header {
+  background: rgba(0,0,0,0.4);
+  border-bottom: 1px solid #ff5722;
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+  margin: -1.5rem -1.5rem 1rem;
+  padding: 1rem 1.5rem;
+}
+
+.premium-modal .modal-title {
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.premium-modal .btn-close {
+  background: transparent;
+  color: #fff;
+  opacity: 1;
+  font-size: 1.5rem;
+}
+
+.premium-modal .btn-close:hover {
+  color: #ff5722;
+}
+
+.dark-input-group .form-control {
+  background-color: #222;
+  border: 1px solid #444;
+  color: #fff;
+}
+
+.dark-input-group .form-control:focus {
+  background-color: #222;
+  color: #fff;
+  border-color: #ff5722;
+  box-shadow: 0 0 0 0.25rem rgba(255,87,34,0.25);
+}
+
+.dark-input-group .input-group-text {
+  background-color: #222;
+  border: 1px solid #444;
+  color: #fff;
+}
+
+.premium-modal-section-title {
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+  border-bottom: 1px solid #ff5722;
+  padding-bottom: 0.25rem;
+}
+
+.premium-submit {
+  background: linear-gradient(45deg, #ff5722, #ff9800);
+  border: none;
+  color: #fff;
+}
+
+.premium-submit:hover {
+  opacity: 0.9;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- redesign login and register modals with premium styling
- add Bootstrap Icons for input icons
- validate username/email availability
- style new premium modal components

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685b8399df4c83248556c6ad111626af