### PR TITLE
Estiliza botón de cierre en modales

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -10,7 +10,14 @@ export default function LoginModal() {
               <img src="/img/logo.png" alt="logo" style={{ height: '30px' }} />
               Inicia sesión
             </h5>
-            <button type="button" className="btn-close rounded-circle" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button
+              type="button"
+              className="modal-close-btn"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
           </div>
           <div className="modal-body">
             <form>

--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -151,7 +151,14 @@ export default function RegisterModal() {
               <img src="/img/logo.png" alt="logo" style={{ height: '30px' }} />
               Crea tu cuenta
             </h5>
-            <button type="button" className="btn-close rounded-circle" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button
+              type="button"
+              className="modal-close-btn"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
           </div>
           <div className="modal-body">
             {message && (

--- a/src/components/ReservationModal.tsx
+++ b/src/components/ReservationModal.tsx
@@ -69,7 +69,14 @@ export default function ReservationModal() {
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title">Haz tu reserva</h5>
-            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <button
+              type="button"
+              className="modal-close-btn"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
           </div>
           <div className="modal-body">
             {message && (

--- a/src/index.css
+++ b/src/index.css
@@ -110,15 +110,31 @@ section {
   gap: 0.5rem;
 }
 
-.premium-modal .btn-close {
-  background: transparent;
-  color: #fff;
-  opacity: 1;
-  font-size: 1.5rem;
+
+.modal-header {
+  position: relative;
 }
 
-.premium-modal .btn-close:hover {
-  color: #ff5722;
+.modal-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: transparent;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  transition: background 0.2s;
+}
+
+.modal-close-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .dark-input-group .form-control {


### PR DESCRIPTION
## Summary
- show a bigger close button with Bootstrap icon
- keep the button in the top-right of the modal

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685b858a530c832498fb567510578ab6