### PR TITLE
Move supabase credentials to dedicated config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This project contains a Node.js/React application and Python module for managing
 
 ## Environment Variables
 
-Create a `.env` file in the project root with your configuration. An example file
-is provided as `.env.example` and a preconfigured `.env` is checked in with
-default Supabase credentials.
+Create a `.env` file in the project root with your database configuration. An example
+file is provided as `.env.example`.
+
+Supabase credentials are stored in `server/config.js`. Edit that file to update
+`SUPABASE_URL` and `SUPABASE_ANON_KEY`.
 
 If you want to start from the template, run:
 
@@ -14,11 +16,9 @@ If you want to start from the template, run:
 cp .env.example .env
 ```
 
-Edit `.env` and set the following variables (or use the provided defaults):
+Edit `.env` and set the following variable:
 
 - `DATABASE_URL` – PostgreSQL connection string (e.g., your Supabase database URL)
-- `SUPABASE_URL` – URL of your Supabase project
-- `SUPABASE_ANON_KEY` – Supabase anonymous API key
 - `PORT` – (optional) server port, defaults to `3000`
 
 The `server/supabaseClient.js` module uses these variables to initialize a Supabase client.

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,3 @@
+export const SUPABASE_URL = 'https://gnxcibehjpvagydkntwt.supabase.co';
+export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdueGNpYmVoanB2YWd5ZGtudHd0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MjM2OTUsImV4cCI6MjA2NjM5OTY5NX0.yOFoSzt16Otr2Zk6ki9fE1Rqc4ResCiXcW7LIYm5_BE';
+export const DATABASE_URL = process.env.DATABASE_URL || '';

--- a/server/db.js
+++ b/server/db.js
@@ -1,7 +1,8 @@
 import { Pool } from 'pg';
+import { DATABASE_URL } from './config.js';
 
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: DATABASE_URL,
 });
 
 export default pool;

--- a/server/supabaseClient.js
+++ b/server/supabaseClient.js
@@ -1,6 +1,4 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- move supabase URL and anon key into `server/config.js`
- update supabase client and DB code to import from the config file
- document new config in README

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685b89a20b4c8324a76804c3c02cec7b