### PR TITLE
Use Vite to bundle CSS frameworks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" integrity="sha512-b7k4czSCsjs0hKHrXhzjUMKoC/QzDNRR/ENzN8eM6x6upqG9pFwgKuG7ZL4qvh0Mcb5+l5fJLe9c5Q3OgEAAhw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/hover.css/2.3.2/css/hover-min.css" integrity="sha512-wS3UtTDvJBD5nQkMA6FbdjtpttbOzV4tb3a7N+FhF38sZ4N2VNivXzXcX4Jt9V7H5PHeTtNKgHdwNwp0UrEG7A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- CSS frameworks are imported via Vite bundling -->
     <title>Alrock Burger</title>
   </head>
   <body>
     <div id="app"></div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "@supabase/supabase-js": "^2.39.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
+    "animate.css": "^4.1.1",
+    "hover.css": "^2.3.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './app'
+import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap-icons/font/bootstrap-icons.css'
+import 'animate.css'
+import 'hover.css/css/hover-min.css'
+import 'bootstrap/dist/js/bootstrap.bundle.min.js'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- remove CDN `<link>` tags
- import Bootstrap and other frameworks via `src/main.tsx`
- list CSS frameworks in `package.json`

## Testing
- `npm run build` *(fails: cannot access registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685b8a00dbe08324a43626c05d0272e5