### PR TITLE
Load frontend CSS/JS from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ npm run start
 ```
 
 This starts the Express server defined in `server/`.
+
+The frontend styles and scripts (Bootstrap, Bootstrap Icons, Animate.css and
+Hover.css) are loaded from CDN links declared in `index.html`, so these packages
+do not need to be installed locally when running the client.

--- a/index.html
+++ b/index.html
@@ -4,11 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSS frameworks are imported via Vite bundling -->
+    <!-- CSS frameworks are loaded from CDN -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css" rel="stylesheet" />
     <title>Alrock Burger</title>
   </head>
   <body>
     <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './app'
-import 'bootstrap/dist/css/bootstrap.min.css'
-import 'bootstrap-icons/font/bootstrap-icons.css'
-import 'animate.css'
-import 'hover.css/css/hover-min.css'
-import 'bootstrap/dist/js/bootstrap.bundle.min.js'
+// Bootstrap and other CSS frameworks are loaded via CDN links in `index.html`
+// so we do not bundle them from `node_modules`.
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- avoid bundling Bootstrap and other styles from node_modules
- load Bootstrap, Bootstrap Icons, Animate.css and Hover.css from CDN
- clarify CDN usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b8c8d2ce08324bb1ecb16e5da2158