### PR TITLE
Fix react-select import issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "react-router-dom": "^6.22.3",
     "@supabase/supabase-js": "^2.39.2",
     "cors": "^2.8.5",
-    "react-select": "^5.7.3",
     "react-datepicker": "^4.24.0"
   },
   "devDependencies": {

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+export interface Option {
+  value: string
+  label: string
+}
+
+interface Props {
+  classNamePrefix?: string
+  options: Option[]
+  value: Option | null
+  onChange: (option: Option | null) => void
+  placeholder?: string
+  isDisabled?: boolean
+}
+
+export default function CustomSelect({
+  classNamePrefix,
+  options,
+  value,
+  onChange,
+  placeholder,
+  isDisabled
+}: Props) {
+  return (
+    <select
+      className={`form-select ${classNamePrefix ? classNamePrefix + '__control' : ''}`}
+      value={value?.value ?? ''}
+      onChange={e => {
+        const selected = options.find(o => o.value === e.target.value) || null
+        onChange(selected)
+      }}
+      disabled={isDisabled}
+    >
+      <option value="" disabled>
+        {placeholder || 'Seleccione'}
+      </option>
+      {options.map(opt => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import Select from 'react-select'
+import CustomSelect from './CustomSelect'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 
@@ -360,7 +360,7 @@ export default function RegisterModal() {
                 <div className="input-group dark-input-group">
                   <span className="input-group-text"><i className="bi bi-flag-fill" /></span>
                   <div className="flex-grow-1">
-                    <Select
+                    <CustomSelect
                       classNamePrefix="premium-select"
                       options={countryOptions}
                       value={countryOptions.find(c => c.label === form.country) || null}
@@ -376,7 +376,7 @@ export default function RegisterModal() {
                 <div className="input-group dark-input-group">
                   <span className="input-group-text"><i className="bi bi-building" /></span>
                   <div className="flex-grow-1">
-                    <Select
+                    <CustomSelect
                       classNamePrefix="premium-select"
                       options={cityOptions}
                       value={cityOptions.find(c => c.label === form.city) || null}

--- a/src/index.css
+++ b/src/index.css
@@ -240,23 +240,20 @@ section {
 .text-brand {
   color: #ff5722 !important;
 }
-/* Premium react-select styles */
+/* Premium select styles */
 .premium-select__control {
   background-color: #222;
   border: 1px solid #444;
   color: #fff;
 }
-.premium-select__control--is-focused {
+.premium-select__control:focus {
   border-color: #ff5722;
   box-shadow: 0 0 0 0.25rem rgba(255,87,34,0.25);
 }
-.premium-select__menu {
+.premium-select__control option {
   background-color: #222;
   color: #fff;
 }
-.premium-select__option--is-focused {
-  background-color: #333;
-}
-.premium-select__option--is-selected {
+.premium-select__control option:checked {
   background-color: #ff5722;
 }


### PR DESCRIPTION
## Summary
- remove `react-select` dependency
- create a lightweight `CustomSelect` component
- update RegisterModal to use `CustomSelect`
- restyle select elements in `index.css`

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685b8f2de5ec8324813aaee3c1b35628