### PR TITLE
Increase hero heading margin

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,7 @@ export default function Hero() {
       }}>
       <div className="container">
 
-        <h1 className="display-1 fw-bold mb-4 mt-5 hero-title animate__animated animate__fadeInDown">
+        <h1 className="display-1 fw-bold mb-4 mt-6 hero-title animate__animated animate__fadeInDown">
           ¡La mejor hamburguesa de la ciudad!
         </h1>
         <button

--- a/src/index.css
+++ b/src/index.css
@@ -313,3 +313,8 @@ section {
   box-shadow: 0 1rem 1.5rem rgba(255, 87, 34, 0.6);
   color: #fff;
 }
+
+/* Additional spacing utility to complement Bootstrap */
+.mt-6 {
+  margin-top: 4.5rem !important;
+}


### PR DESCRIPTION
## Summary
- add extra margin-top utility in CSS
- apply new margin to hero heading

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685b9bb7521883249dd66e9f46291280