### PR TITLE
Update API URL to use client constant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Example environment configuration for Hackton
 PORT=3000
-VITE_API_URL=http://localhost:3000
+# The API_URL used by the React app is defined in src/supabaseClient.tsx
 DATABASE_URL=postgresql://username:password@db.host/supabase_db
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ file is provided as `.env.example`.
 
 Supabase credentials are stored in `server/config.js` for the API server and in
 `src/supabaseClient.tsx` for the React application. Edit either file to update
-`SUPABASE_URL` and `SUPABASE_ANON_KEY`.
+`SUPABASE_URL` and `SUPABASE_ANON_KEY`. The API base URL used by the React app
+is also defined in `src/supabaseClient.tsx` as `API_URL`.
 
 If you want to start from the template, run:
 

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { API_URL } from '../supabaseClient'
 
 interface Product {
   id: number

--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { API_URL } from '../supabaseClient'
 
 interface FormState {
   username: string

--- a/src/components/ReservationModal.tsx
+++ b/src/components/ReservationModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { API_URL } from '../supabaseClient'
 
 interface FormState {
   customer_name: string

--- a/src/supabaseClient.tsx
+++ b/src/supabaseClient.tsx
@@ -3,6 +3,9 @@ import { createClient } from '@supabase/supabase-js'
 const SUPABASE_URL = 'https://gnxcibehjpvagydkntwt.supabase.co'
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdueGNpYmVoanB2YWd5ZGtudHd0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MjM2OTUsImV4cCI6MjA2NjM5OTY5NX0.yOFoSzt16Otr2Zk6ki9fE1Rqc4ResCiXcW7LIYm5_BE'
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+export const API_URL = 'http://localhost:3000'
 
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
 export default supabase
+
+export { supabase }


### PR DESCRIPTION
## Summary
- centralize API URL in `src/supabaseClient.tsx`
- import `API_URL` from client in each component
- clarify API URL location in README
- note API URL in `.env.example`

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685b9e01d88c83248ca0509fa465da01