### PR TITLE
Add Supabase client and auth modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^18.3.1",
     "react-datepicker": "^4.24.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "@supabase/supabase-js": "^2.39.7"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'crypto'
+import { supabase, Logger } from './supabaseClient'
+
+export interface RegistrationData {
+  username: string
+  user: string
+  email: string
+  password: string
+  phone: string
+  birth_date: string
+  address: string
+  accepted_terms: boolean
+  registration_ip: string
+  country: string
+  city: string
+}
+
+export interface AuthUser extends Omit<Logger, 'password'> {}
+
+export async function registerUser(data: RegistrationData): Promise<AuthUser> {
+  const passwordHash = createHash('sha256').update(data.password).digest('hex')
+  const { data: inserted, error } = await supabase
+    .from('logger')
+    .insert({
+      username: data.username,
+      user: data.user,
+      role: 'user',
+      email: data.email,
+      password: passwordHash,
+      phone: data.phone,
+      birth_date: data.birth_date,
+      address: data.address,
+      accepted_terms: data.accepted_terms,
+      registration_ip: data.registration_ip,
+      country: data.country,
+      city: data.city
+    })
+    .select()
+    .single()
+  if (error) throw error
+  const { password, ...rest } = inserted as Logger
+  return rest
+}
+
+export async function loginUser(email: string, password: string, ip: string): Promise<AuthUser> {
+  const passwordHash = createHash('sha256').update(password).digest('hex')
+  const { data: user, error } = await supabase.from('logger').select('*').eq('email', email).single()
+  if (error) throw error
+  if (!user || user.password !== passwordHash) throw new Error('Invalid credentials')
+  const { data: updated, error: updateError } = await supabase
+    .from('logger')
+    .update({ last_ip: ip, last_login: new Date().toISOString() })
+    .eq('id', user.id)
+    .select()
+    .single()
+  if (updateError) throw updateError
+  const { password: pwd, ...rest } = updated as Logger
+  return rest
+}

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,0 +1,58 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = 'https://gnxcibehjpvagydkntwt.supabase.co'
+const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdueGNpYmVoanB2YWd5ZGtudHd0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MjM2OTUsImV4cCI6MjA2NjM5OTY5NX0.yOFoSzt16Otr2Zk6ki9fE1Rqc4ResCiXcW7LIYm5_BE'
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export interface Logger {
+  id: string
+  username: string
+  user: string
+  role: string
+  email: string
+  password: string
+  phone: string
+  birth_date: string
+  address: string
+  accepted_terms: boolean
+  registration_ip: string
+  last_ip: string | null
+  last_login: string | null
+  country: string
+  city: string
+  registration_date: string
+}
+
+export async function createLogger(data: Omit<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login'> & Partial<Pick<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login' | 'role'>>): Promise<Logger> {
+  const record = { ...data, role: data.role ?? 'user' }
+  const { data: inserted, error } = await supabase
+    .from('logger')
+    .insert(record)
+    .select()
+    .single()
+  if (error) throw error
+  return inserted as Logger
+}
+
+export async function getLogger(id: string): Promise<Logger> {
+  const { data, error } = await supabase.from('logger').select('*').eq('id', id).single()
+  if (error) throw error
+  return data as Logger
+}
+
+export async function updateLogger(id: string, updates: Partial<Omit<Logger, 'id'>>): Promise<Logger> {
+  const { data, error } = await supabase
+    .from('logger')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return data as Logger
+}
+
+export async function deleteLogger(id: string): Promise<void> {
+  const { error } = await supabase.from('logger').delete().eq('id', id)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary
- configure Supabase client
- provide CRUD helpers for table `logger`
- add auth module with register and login logic
- include `@supabase/supabase-js` dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685bf853251c8324b516e9d4b49c4306