### PR TITLE
Add Supabase product fetch

### DIFF
--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,22 +1,15 @@
 import React, { useEffect, useState } from 'react'
-
-// Backend interactions removed
-
-interface Product {
-  id: number
-  image: string
-  title: string
-  description: string
-  price: number
-}
+import { getProducts, Product } from '../products'
 
 export default function Products() {
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
-    // Backend removed; no data loading
-    setProducts([])
+    setLoading(true)
+    getProducts()
+      .then(data => setProducts(data))
+      .finally(() => setLoading(false))
   }, [])
 
   function formatPrice(value: number) {

--- a/src/products.ts
+++ b/src/products.ts
@@ -1,0 +1,18 @@
+import { supabase } from './supabaseClient'
+
+export interface Product {
+  id: number
+  image: string
+  title: string
+  description: string
+  price: number
+}
+
+export async function getProducts(): Promise<Product[]> {
+  const { data, error } = await supabase
+    .from('products')
+    .select('id, image, title, description, price')
+
+  if (error) throw error
+  return (data as Product[]) || []
+}


### PR DESCRIPTION
## Summary
- add `getProducts` helper that fetches records from `products` table in Supabase
- display fetched products in `Products` component

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685bfae158d883249e9919c2d7d44d6a