### PR TITLE
Fix auth Logger import and hover.css link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/hover.css/2.3.2/css/hover-min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magic/1.1.0/magic.min.css" />
     <title>Alrock Burger</title>
   </head>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,24 @@
 import { createHash } from 'crypto'
-import { supabase, Logger } from './supabaseClient'
+import { supabase } from './supabaseClient'
+
+export type Logger = {
+  id: number
+  username: string | null
+  user: string | null
+  role: string | null
+  email: string | null
+  password: string | null
+  phone: string | null
+  birth_date: string | null
+  address: string | null
+  accepted_terms: boolean | null
+  registration_ip: string | null
+  last_ip: string | null
+  last_login: string | null
+  country: string | null
+  city: string | null
+  registration_date: string | null
+}
 
 export interface RegistrationData {
   username: string


### PR DESCRIPTION
## Summary
- define Logger type directly in `auth.ts`
- update hover.css link to use jsdelivr CDN

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe0191588324aac7b992a185a707