### PR TITLE
Show product prices in COP

### DIFF
--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -14,7 +14,12 @@ export default function Products() {
   }, [])
 
   function formatPrice(value: number) {
-    return value.toLocaleString('es-ES', { style: 'currency', currency: 'USD' })
+    return (
+      value.toLocaleString('es-ES', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      }) + ' $ COP'
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- update price formatting to display COP values instead of USD

## Testing
- `npm run build` *(fails: Cannot find module 'react'...)*

------
https://chatgpt.com/codex/tasks/task_e_685c010c8d608324bd44516ac47288d4