### PR TITLE
Fix React imports and event typing

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Header from './components/Header'
 import LoginModal from './components/LoginModal'

--- a/src/components/ConsultReservation.tsx
+++ b/src/components/ConsultReservation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState, type FormEvent } from 'react'
 import { findReservationByCode } from '../reservations'
 
 export default function ConsultReservation() {
@@ -6,7 +6,7 @@ export default function ConsultReservation() {
   const [message, setMessage] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
       const res = await findReservationByCode(code.trim())

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function Contact() {
   return (
     <section id="contacto" className="py-5 bg-light">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function Footer() {
   return (
     <footer className="premium-footer mt-auto pt-5 text-white">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 export default function Header() {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import ConsultReservation from './ConsultReservation'
 
 export default function Hero() {

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState, type FormEvent } from 'react'
 import { loginUser } from '../auth'
 
 export default function LoginModal() {
@@ -7,7 +7,7 @@ export default function LoginModal() {
   const [message, setMessage] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
       await loginUser(email, password, window.location.hostname)

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { getProducts } from '../products'
 import type { Product } from '../products'
 

--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect, type ChangeEvent, type FormEvent } from 'react'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import { registerUser } from '../auth'
@@ -69,8 +69,9 @@ export default function RegisterModal() {
     return
   }
 
-  function updateField(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
-    const { name, value, type, checked } = e.target
+  function updateField(e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    const target = e.target as HTMLInputElement | HTMLSelectElement
+    const { name, value, type, checked } = target
     const val = type === 'checkbox' ? checked : value
     setForm(f => ({ ...f, [name]: val }))
     if (errors[name]) {
@@ -117,7 +118,7 @@ export default function RegisterModal() {
     }
   }, [form.password, form.repeat_password])
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     const reqFields = ['username', 'user', 'email', 'repeat_email', 'password', 'repeat_password', 'country', 'city', 'birth_date']
     const newErrors: Record<string, string> = {}

--- a/src/components/ReservationModal.tsx
+++ b/src/components/ReservationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState, type ChangeEvent, type FormEvent } from 'react'
 import { createReservation } from '../reservations'
 
 interface FormState {
@@ -24,12 +24,12 @@ export default function ReservationModal() {
   const [message, setMessage] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
-  function updateField(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+  function updateField(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     const { name, value } = e.target
     setForm(f => ({ ...f, [name]: value }))
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
       const res = await createReservation({

--- a/src/components/WhatsAppButton.tsx
+++ b/src/components/WhatsAppButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 export default function WhatsAppButton() {
   const [hover, setHover] = useState(false)

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function About() {
   return (
     <div className="container py-5 mt-4">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Hero from '../components/Hero'
 import Products from '../components/Products'
 

--- a/src/react-datepicker.d.ts
+++ b/src/react-datepicker.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-datepicker';


### PR DESCRIPTION
## Summary
- remove unused React imports across components
- import React types instead of React namespace
- cast form field events in register modal
- declare module for `react-datepicker`

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685c067d6fb48324ba80d0808f2afe26