### PR TITLE
Fix updateField typing

### DIFF
--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -69,10 +69,10 @@ export default function RegisterModal() {
     return
   }
 
-  function updateField(e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
-    const target = e.target as HTMLInputElement | HTMLSelectElement
-    const { name, value, type, checked } = target
-    const val = type === 'checkbox' ? checked : value
+  function updateField(e: ChangeEvent<HTMLInputElement>) {
+    const target = e.target
+    const { name, value, type } = target
+    const val = type === 'checkbox' ? target.checked : value
     setForm(f => ({ ...f, [name]: val }))
     if (errors[name]) {
       if (val) {


### PR DESCRIPTION
## Summary
- fix `updateField` signature to use `HTMLInputElement`

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685c0879e4988324a53140b0ffbe7b3e