### PR TITLE
Fix consult reservation modal close button and hide empty rows

### DIFF
--- a/src/components/ConsultReservation.tsx
+++ b/src/components/ConsultReservation.tsx
@@ -58,12 +58,10 @@ export default function ConsultReservation() {
               </h5>
               <button
                 type="button"
-                className="modal-close-btn"
+                className="btn-close btn-close-white position-absolute top-0 end-0 m-3"
                 data-bs-dismiss="modal"
                 aria-label="Close"
-              >
-                <i className="bi bi-x-lg" />
-              </button>
+              />
             </div>
             <div className="modal-body">
               {error ? (
@@ -73,14 +71,22 @@ export default function ConsultReservation() {
                 </div>
               ) : reservation && (
                 <ul className="list-unstyled mb-0">
-                  <li className="mb-2"><i className="bi bi-person-badge-fill me-2" />Nombre de usuario: {reservation.customer_username ?? 'N/A'}</li>
+                  {reservation.customer_username && reservation.customer_username.trim() !== '' && (
+                    <li className="mb-2">
+                      <i className="bi bi-person-badge-fill me-2" />Nombre de usuario: {reservation.customer_username}
+                    </li>
+                  )}
                   <li className="mb-2"><i className="bi bi-person-fill me-2" />Nombre completo: {reservation.customer_name ?? 'N/A'}</li>
                   <li className="mb-2"><i className="bi bi-telephone-fill me-2" />Teléfono: {reservation.customer_phone ?? 'N/A'}</li>
                   <li className="mb-2"><i className="bi bi-phone-fill me-2" />Celular: {reservation.customer_mobile ?? 'N/A'}</li>
                   <li className="mb-2"><i className="bi bi-envelope-fill me-2" />Correo electrónico: {reservation.customer_email ?? 'N/A'}</li>
                   <li className="mb-2"><i className="bi bi-calendar-event-fill me-2" />Fecha y hora: {new Date(reservation.reservation_date).toLocaleString()}</li>
                   <li className="mb-2"><i className="bi bi-people-fill me-2" />Número de personas: {reservation.number_of_people}</li>
-                  <li className="mb-2"><i className="bi bi-table me-2" />Mesa asignada: {reservation.table_number ?? 'N/A'}</li>
+                  {reservation.table_number && reservation.table_number.trim() !== '' && (
+                    <li className="mb-2">
+                      <i className="bi bi-table me-2" />Mesa asignada: {reservation.table_number}
+                    </li>
+                  )}
                   <li className="mb-2"><i className="bi bi-chat-square-text-fill me-2" />Peticiones especiales: {reservation.special_requests ?? 'N/A'}</li>
                   <li className="mb-2"><i className="bi bi-info-circle-fill me-2" />Estado: {reservation.status}</li>
                   <li><i className="bi bi-hash me-2" />Código: {reservation.code}</li>


### PR DESCRIPTION
## Summary
- use Bootstrap close button in reservation consult modal so that the modal closes properly
- hide username and table number rows when values are missing

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685d48ef4b348324b07f073ba6e95ae0