### PR TITLE
Fix modal z-index behind overlay

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,11 @@ section {
   backdrop-filter: blur(6px);
 }
 
+/* Ensure custom modals appear above the backdrop */
+.premium-modal {
+  z-index: 1060;
+}
+
 /* Premium modal container */
 .premium-modal .modal-dialog {
   min-height: calc(100vh - 1rem);


### PR DESCRIPTION
## Summary
- ensure custom modals appear above their backdrop by assigning a higher z-index

## Testing
- `npm run build` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_685d4bb938dc8324bbce7020233cc3e0