### PR TITLE
Log user_agent in login history

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,16 @@ async function sha256(message: string): Promise<string> {
     .join('')
 }
 
+export type LoginRecord = {
+  ip: string
+  timestamp: string
+  /**
+   * Navegador o dispositivo utilizado durante el inicio de sesión.
+   * Puede no existir en registros antiguos.
+   */
+  user_agent?: string
+}
+
 export type Logger = {
   id: number
   username: string | null
@@ -22,6 +32,7 @@ export type Logger = {
   registration_ip: string | null
   last_ip: string | null
   last_login: string | null
+  login_history: LoginRecord[] | null
   country: string | null
   city: string | null
   registration_date: string | null
@@ -59,7 +70,8 @@ export async function registerUser(data: RegistrationData): Promise<AuthUser> {
       accepted_terms: data.accepted_terms,
       registration_ip: data.registration_ip,
       country: data.country,
-      city: data.city
+      city: data.city,
+      login_history: []
     })
     .select()
     .single()
@@ -68,14 +80,31 @@ export async function registerUser(data: RegistrationData): Promise<AuthUser> {
   return rest
 }
 
-export async function loginUser(email: string, password: string, ip: string): Promise<AuthUser> {
+export async function loginUser(
+  email: string,
+  password: string,
+  ip: string,
+  userAgent: string
+): Promise<AuthUser> {
   const passwordHash = await sha256(password)
-  const { data: user, error } = await supabase.from('logger').select('*').eq('email', email).single()
+  const { data: user, error } = await supabase
+    .from('logger')
+    .select('*')
+    .eq('email', email)
+    .single()
   if (error) throw error
   if (!user || user.password !== passwordHash) throw new Error('Invalid credentials')
+
+  const history = Array.isArray(user.login_history) ? user.login_history : []
+  history.push({ ip, timestamp: new Date().toISOString(), user_agent: userAgent })
+
   const { data: updated, error: updateError } = await supabase
     .from('logger')
-    .update({ last_ip: ip, last_login: new Date().toISOString() })
+    .update({
+      last_ip: ip,
+      last_login: new Date().toISOString(),
+      login_history: history
+    })
     .eq('id', user.id)
     .select()
     .single()

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -10,7 +10,7 @@ export default function LoginModal() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
-      await loginUser(email, password, window.location.hostname)
+      await loginUser(email, password, window.location.hostname, navigator.userAgent)
       setSuccess(true)
       setMessage('Inicio de sesión exitoso')
       setEmail('')

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -5,6 +5,16 @@ const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYm
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
+export interface LoginRecord {
+  ip: string
+  timestamp: string
+  /**
+   * Navegador o dispositivo utilizado durante el inicio de sesión.
+   * Puede no existir en registros antiguos.
+   */
+  user_agent?: string
+}
+
 export interface Logger {
   id: string
   username: string
@@ -19,13 +29,22 @@ export interface Logger {
   registration_ip: string
   last_ip: string | null
   last_login: string | null
+  /** Historial de inicios de sesión */
+  login_history: LoginRecord[] | null
   country: string
   city: string
   registration_date: string
 }
 
-export async function createLogger(data: Omit<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login'> & Partial<Pick<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login' | 'role'>>): Promise<Logger> {
-  const record = { ...data, role: data.role ?? 'user' }
+export async function createLogger(
+  data: Omit<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login' | 'login_history'> &
+    Partial<Pick<Logger, 'id' | 'registration_date' | 'last_ip' | 'last_login' | 'login_history' | 'role'>>
+): Promise<Logger> {
+  const record = {
+    ...data,
+    role: data.role ?? 'user',
+    login_history: data.login_history ?? []
+  }
   const { data: inserted, error } = await supabase
     .from('logger')
     .insert(record)


### PR DESCRIPTION
## Summary
- define `LoginRecord` in auth and supabase client typings
- track `login_history` when users log in
- send `navigator.userAgent` from the login form
- default new `login_history` arrays when creating loggers

## Testing
- `npm run build` *(fails: Cannot find modules and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d4c824c60832488a11e7b43466449