### PR TITLE
Actualizar botón a 'Comprar' con nuevo modal

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header'
 import LoginModal from './components/LoginModal'
 import RegisterModal from './components/RegisterModal'
 import ReservationModal from './components/ReservationModal'
+import BuyModal from './components/BuyModal'
 import Footer from './components/Footer'
 import WhatsAppButton from './components/WhatsAppButton'
 import Home from './pages/Home'
@@ -16,6 +17,7 @@ export default function App() {
       <LoginModal />
       <RegisterModal />
       <ReservationModal />
+      <BuyModal />
       <main className="flex-grow-1">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/BuyModal.tsx
+++ b/src/components/BuyModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+export default function BuyModal() {
+  return (
+    <div className="modal fade premium-modal" id="buyPromptModal" tabIndex={-1} aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">
+              <img src="/img/logo.png" alt="logo" style={{ height: '30px' }} />
+              Aviso de compra
+            </h5>
+            <button
+              type="button"
+              className="modal-close-btn"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
+          </div>
+          <div className="modal-body text-center">
+            <p className="lead mb-4">Primero debes registrarte para poder comprar.</p>
+            <button
+              type="button"
+              className="btn premium-submit w-100"
+              data-bs-dismiss="modal"
+              data-bs-toggle="modal"
+              data-bs-target="#registerModal"
+            >
+              Ir al registro
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -49,7 +49,13 @@ export default function Products() {
                       <span className="badge bg-warning text-dark fs-6">
                         {formatPrice(prod.price)}
                       </span>
-                      <button className="btn btn-primary">Reservar</button>
+                      <button
+                        className="btn btn-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#buyPromptModal"
+                      >
+                        Comprar
+                      </button>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace `Reservar` button with `Comprar` in product cards
- add modal `BuyModal` warning users to register before purchasing
- include the new modal in the application layout

## Testing
- `npm run build` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d4f60fe1c8324848fcd7ad7b7b861