### PR TITLE
Fix unused React import in BuyModal

### DIFF
--- a/src/components/BuyModal.tsx
+++ b/src/components/BuyModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function BuyModal() {
   return (
     <div className="modal fade premium-modal" id="buyPromptModal" tabIndex={-1} aria-hidden="true">


### PR DESCRIPTION
## Summary
- remove unused `React` import from `BuyModal.tsx`

## Testing
- `npm run build` *(fails: Cannot find module `react`, `react-dom/client`, `react-router-dom`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685d56dbd22883249c8cdefc6330addb